### PR TITLE
actualizacion cors app.js localhost:3000

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const {loadPaymentMethods} = require('./src/controllers/PaymentMethod.controller
 const port = process.env.PORT || 3001;
 
 // Syncing all the models at once.
-conn.sync({ alter: true }).then(async() => {
+conn.sync({ force: true }).then(async() => {
   await createDbTools();
   await createDbCategories();
   await loadPaymentMethods();

--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,7 @@ server.use(bodyParser.json({ limit: '50mb' }));
 server.use(morgan('dev'));
 server.use(cookieParser())
 server.use((req, res, next) => {
-  res.header('Access-Control-Allow-Origin', '*'); // update to match the domain you will make the request from
+  res.header('Access-Control-Allow-Origin', 'http://localhost:3000'); // Reemplaza con el dominio correcto del front-end
   res.header('Access-Control-Allow-Credentials', 'true');
   res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
   res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, DELETE');


### PR DESCRIPTION
stackoverflow: Falta la cabecera CORS 'Access-Control-Allow-Origin' Es importante tener en cuenta que permitir el acceso desde cualquier origen (*) puede ser un riesgo de seguridad en producción, ya que cualquier sitio web podría realizar solicitudes a tu servidor. Es recomendable especificar el dominio exacto del front-end para el encabezado Access-Control-Allow-Origin